### PR TITLE
Add member authentication pages and adjust booking spacing

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,6 +27,8 @@
         <a href="about.html" aria-current="page">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
+        <a href="member.html">會員中心</a>
       </nav>
       <a class="btn btn-outline" href="booking.html#booking-form">預約體驗課</a>
     </div>
@@ -284,6 +286,8 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
+        <a href="member.html">會員中心</a>
       </div>
       <div class="footer-block">
         <span class="footer-title">聯絡資訊</span>

--- a/about.html
+++ b/about.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>關於我們 | TennisPro Club</title>
-  <meta name="description" content="了解 TennisPro Club 的創立故事、訓練理念與專業團隊，探索我們如何陪伴每位學員在球場上持續前進。">
+  <title>關於我們 | 樂活網球 Club</title>
+  <meta name="description" content="了解 樂活網球 Club 的創立故事、訓練理念與專業團隊，探索我們如何陪伴每位學員在球場上持續前進。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -40,7 +40,7 @@
       <div class="container about-hero__content">
         <p class="eyebrow">Our Story</p>
         <h1>在這裡，網球是生活，更是持續成長的旅程</h1>
-        <p>2014 年，我們從一項「讓每位學員都擁有專屬教練與訓練藍圖」的使命出發。十年過去，TennisPro Club 已成為結合教練、體能、心理與數據分析的專業訓練基地，陪伴超過 3,800 位學員在球場上建立自信。</p>
+        <p>2014 年，我們從一項「讓每位學員都擁有專屬教練與訓練藍圖」的使命出發。十年過去，樂活網球 Club 已成為結合教練、體能、心理與數據分析的專業訓練基地，陪伴超過 3,800 位學員在球場上建立自信。</p>
         <div class="hero-actions">
           <a class="btn btn-primary" href="booking.html">立即預約場地</a>
           <a class="btn btn-ghost" href="team.html">認識教練團隊</a>
@@ -53,7 +53,7 @@
         <div class="story-text">
           <p class="eyebrow">我們的初心</p>
           <h2>從青少年球隊開始的教練夢</h2>
-          <p>創辦人團隊走遍世界各地的網球學校，看見真正能改變球員的，是教練在場上與場下的陪伴。TennisPro 因此以「專屬教練＋科學化訓練」為核心，打造台灣首座結合技術、體能、策略與心理的整合訓練場景。</p>
+          <p>創辦人團隊走遍世界各地的網球學校，看見真正能改變球員的，是教練在場上與場下的陪伴。樂活網球 因此以「專屬教練＋科學化訓練」為核心，打造台灣首座結合技術、體能、策略與心理的整合訓練場景。</p>
           <ul class="story-list">
             <li>教練與體能團隊 1:1 管理，每位學員皆有專屬檔案。</li>
             <li>導入體感追蹤、擊球速度與步伐分析，將進步量化。</li>
@@ -199,7 +199,7 @@
         </div>
         <div class="testimonial-grid">
           <article class="testimonial-card is-active">
-            <p>「TennisPro 會在每次訓練前設定重點，結束後立即整理成影片回顧，讓我能在家持續修正。教練的陪伴讓我從企業聯賽的板凳，到現在的先發主力。」</p>
+            <p>「樂活網球 會在每次訓練前設定重點，結束後立即整理成影片回顧，讓我能在家持續修正。教練的陪伴讓我從企業聯賽的板凳，到現在的先發主力。」</p>
             <div class="testimonial-meta">
               <span class="name">陳亭如</span>
               <span class="role">企業聯賽選手</span>
@@ -277,7 +277,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
       </div>
       <div class="footer-block">
@@ -305,7 +305,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>c 2024 TennisPro Club. 版權所有。</span>
+      <span>c 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/booking-big5.txt
+++ b/booking-big5.txt
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>??蝬脩??游 | TennisPro Club</title>
-  <meta name="description" content="蝺??亥岷 TennisPro Club ?游??蝺湔?畾蛛?敹恍???蝝蒂?閮毀?寞???>
+  <title>??蝬脩??游 | 樂活網球 Club</title>
+  <meta name="description" content="蝺??亥岷 樂活網球 Club ?游??蝺湔?畾蛛?敹恍???蝝蒂?閮毀?寞???>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 擐?">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 擐?">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -308,7 +308,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>?靽⊥?雿飛?⊿?澆???撠惇??蝺渲???敺洵銝憿???撱箇?瘞貊??飛蝧??賬?/p>
       </div>
       <div class="footer-block">
@@ -335,7 +335,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>穢 2024 TennisPro Club. ?????/span>
+      <span>穢 2024 樂活網球 Club. ?????/span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/booking.html
+++ b/booking.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>預約球場與教練 | TennisPro Club</title>
-  <meta name="description" content="線上預約 TennisPro Club 球場與教練時段，快速完成預定並掌握訓練安排。">
+  <title>預約球場與教練 | 樂活網球 Club</title>
+  <meta name="description" content="線上預約 樂活網球 Club 球場與教練時段，快速完成預定並掌握訓練安排。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -309,7 +309,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬教練，從第一顆球開始打造長期且樂在其中的學習旅程。</p>
       </div>
       <div class="footer-block">
@@ -337,7 +337,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>© 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/booking.html
+++ b/booking.html
@@ -27,6 +27,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html" aria-current="page">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </nav>
       <a class="btn btn-outline" href="#booking-form">預約體驗課</a>
@@ -317,6 +318,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </div>
       <div class="footer-block">

--- a/css/auth.css
+++ b/css/auth.css
@@ -1,0 +1,160 @@
+/* Auth Pages (member-login.html, member-register.html) */
+.auth-hero {
+  background: linear-gradient(135deg, rgba(11, 31, 58, 0.92) 0%, rgba(11, 31, 58, 0.7) 40%, rgba(10, 45, 87, 0.85) 100%),
+    url("https://images.unsplash.com/photo-1535469420027-517674dad7b5?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat;
+  color: #fff;
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+}
+
+.auth-hero .container {
+  display: grid;
+  gap: 40px;
+  align-items: center;
+  width: min(1080px, 92vw);
+}
+
+.auth-copy h1 {
+  font-size: clamp(2rem, 3.8vw, 3rem);
+  color: #fff;
+  margin-bottom: 18px;
+}
+
+.auth-copy p {
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.auth-card {
+  background: #fff;
+  color: var(--primary-color);
+  border-radius: var(--border-radius-lg);
+  padding: 36px 38px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 24px;
+}
+
+.auth-card h2 {
+  margin: 0;
+}
+
+.auth-card p {
+  margin: 0;
+}
+
+.auth-form {
+  display: grid;
+  gap: 18px;
+}
+
+.auth-form .form-field {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-form label {
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.auth-form input,
+.auth-form select {
+  padding: 12px 16px;
+  border-radius: var(--border-radius-sm);
+  border: 1px solid rgba(11, 31, 58, 0.16);
+  font-size: 1rem;
+}
+
+.auth-form input:focus-visible,
+.auth-form select:focus-visible {
+  outline: 2px solid rgba(236, 153, 55, 0.4);
+}
+
+.auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+}
+
+.auth-meta {
+  font-size: 0.95rem;
+  color: var(--muted-color);
+}
+
+.auth-meta a {
+  font-weight: 700;
+}
+
+.auth-page section {
+  padding: 70px 0;
+}
+
+.auth-benefits {
+  background: var(--surface-color);
+}
+
+.benefit-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.benefit-card {
+  background: #fff;
+  border-radius: var(--border-radius-md);
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(11, 31, 58, 0.06);
+  display: grid;
+  gap: 12px;
+}
+
+.benefit-card h3 {
+  margin: 0;
+}
+
+.auth-footer-cta {
+  text-align: center;
+  padding: 80px 0 110px;
+}
+
+.auth-footer-cta h2 {
+  margin-bottom: 18px;
+}
+
+@media (max-width: 960px) {
+  .auth-hero {
+    padding: 100px 0;
+  }
+
+  .auth-hero .container {
+    gap: 26px;
+  }
+
+  .auth-card {
+    padding: 32px;
+  }
+
+  .benefit-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .auth-hero .container {
+    grid-template-columns: 1fr;
+  }
+
+  .benefit-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/css/auth.css
+++ b/css/auth.css
@@ -126,6 +126,10 @@
   margin-bottom: 18px;
 }
 
+.auth-footer-cta .btn {
+  margin-top: 3px;
+}
+
 @media (max-width: 960px) {
   .auth-hero {
     padding: 100px 0;

--- a/css/auth.css
+++ b/css/auth.css
@@ -122,12 +122,26 @@
   padding: 80px 0 110px;
 }
 
+.auth-footer-cta .container {
+  display: grid;
+  gap: 22px;
+  justify-items: center;
+  width: min(92vw, 760px);
+  margin: 0 auto;
+}
+
 .auth-footer-cta h2 {
-  margin-bottom: 18px;
+  margin: 0;
+}
+
+.auth-footer-cta p {
+  margin: 0;
+  max-width: 520px;
+  line-height: 1.75;
 }
 
 .auth-footer-cta .btn {
-  margin-top: 3px;
+  margin-top: 0;
 }
 
 @media (max-width: 960px) {

--- a/css/booking.css
+++ b/css/booking.css
@@ -130,6 +130,10 @@
   gap: 22px;
 }
 
+.slot-grid.is-sample {
+  padding-top: 12px;
+}
+
 .slot-card {
   background: #fff;
   border-radius: var(--border-radius-md);
@@ -138,6 +142,7 @@
   display: grid;
   gap: 12px;
   border: 1px solid rgba(11, 31, 58, 0.05);
+  position: relative;
 }
 
 .slot-card__header {
@@ -157,6 +162,30 @@
 
 .slot-card button {
   justify-self: flex-start;
+}
+
+.slot-summary.is-sample {
+  color: var(--muted-color);
+  font-weight: 500;
+}
+
+.slot-card.is-sample {
+  border: 1px dashed rgba(11, 31, 58, 0.24);
+  box-shadow: none;
+}
+
+.slot-card.is-sample::before {
+  content: "示意";
+  position: absolute;
+  top: -14px;
+  left: 24px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(236, 153, 55, 0.16);
+  color: var(--accent-color);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
 }
 
 .slot-empty {

--- a/css/booking.css
+++ b/css/booking.css
@@ -250,6 +250,10 @@
   color: #fff;
 }
 
+.booking-steps .section-head .eyebrow {
+  margin-bottom: 5px;
+}
+
 .step-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/css/member.css
+++ b/css/member.css
@@ -228,25 +228,30 @@
 }
 
 .target-progress {
-  position: relative;
-  height: 8px;
-  background: rgba(11, 31, 58, 0.08);
-  border-radius: 999px;
-  margin: 18px 0 16px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 18px;
+  margin-top: 6px;
 }
 
-.target-progress span {
-  position: absolute;
-  inset: 0;
+.target-progress__track {
+  position: relative;
+  height: 8px;
+  background: rgba(11, 31, 58, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.target-progress__track span {
+  display: block;
+  height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, #4c9cff 0%, #1f75f0 100%);
 }
 
-.target-value {
-  position: absolute;
-  right: 8px;
-  top: -24px;
-  font-size: 0.85rem;
+.target-progress__value {
+  font-size: 0.95rem;
   font-weight: 700;
   color: var(--primary-color);
 }
@@ -384,5 +389,14 @@
 
   .panel {
     padding: 20px;
+  }
+
+  .target-progress {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .target-progress__value {
+    justify-self: end;
   }
 }

--- a/css/member.css
+++ b/css/member.css
@@ -232,6 +232,7 @@
   height: 8px;
   background: rgba(11, 31, 58, 0.08);
   border-radius: 999px;
+  margin: 18px 0 16px;
 }
 
 .target-progress span {

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>TennisPro 網球教練課程</title>
-  <meta name="description" content="TennisPro 提供客製化網球課程、專業教練團隊與完整訓練資源，協助每位學員提升球技。">
+  <title>樂活網球 網球教練課程</title>
+  <meta name="description" content="樂活網球 提供客製化網球課程、專業教練團隊與完整訓練資源，協助每位學員提升球技。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="#hero" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="#hero" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -187,7 +187,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
       </div>
       <div class="footer-block">
@@ -215,7 +215,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>© 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </nav>
       <a class="btn btn-outline" href="booking.html#booking-form">立即預約</a>
@@ -195,6 +196,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </div>
       <div class="footer-block">

--- a/member-login.html
+++ b/member-login.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>會員登入 | TennisPro Club</title>
+  <meta name="description" content="登入 TennisPro Club 會員專區，管理課程預約、訓練紀錄與會員福利。">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/auth.css">
+  <script defer src="scripts.js"></script>
+</head>
+<body class="auth-page">
+  <header class="site-header" id="top">
+    <div class="container header-bar">
+      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
+        <span class="nav-toggle__bar"></span>
+        <span class="nav-toggle__bar"></span>
+        <span class="nav-toggle__bar"></span>
+        <span class="sr-only">開啟主選單</span>
+      </button>
+      <nav class="main-nav" id="main-nav">
+        <a href="index.html">首頁</a>
+        <a href="about.html">關於我們</a>
+        <a href="booking.html">預約場地</a>
+        <a href="team.html">教練團隊</a>
+        <a href="member-login.html" aria-current="page">會員登入</a>
+        <a href="member.html">會員中心</a>
+      </nav>
+      <a class="btn btn-outline" href="member-register.html">立即加入</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="auth-hero">
+      <div class="container">
+        <div class="auth-copy">
+          <p class="eyebrow">Member Login</p>
+          <h1>登入會員，掌握你的專屬訓練進度</h1>
+          <p>查看最新預約、追蹤訓練成果，並獲得教練團隊的即時回饋。只要登入即可同步管理所有課程與賽事行程。</p>
+        </div>
+        <div class="auth-card" aria-labelledby="login-title">
+          <div>
+            <h2 id="login-title">會員登入</h2>
+            <p>輸入註冊的電子郵件與密碼進入會員中心。</p>
+          </div>
+          <form class="auth-form" aria-describedby="login-title">
+            <div class="form-field">
+              <label for="login-email">電子郵件</label>
+              <input id="login-email" name="email" type="email" placeholder="you@example.com" required>
+            </div>
+            <div class="form-field">
+              <label for="login-password">密碼</label>
+              <input id="login-password" name="password" type="password" placeholder="請輸入密碼" required>
+            </div>
+            <div class="auth-actions">
+              <button class="btn btn-primary" type="submit">登入</button>
+              <a class="btn btn-ghost" href="#">忘記密碼？</a>
+            </div>
+            <p class="auth-meta">還不是會員嗎？<a href="member-register.html">立即註冊</a></p>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="auth-benefits" aria-labelledby="benefit-title">
+      <div class="container">
+        <div class="section-head" style="margin-bottom: 42px;">
+          <p class="eyebrow">會員專屬</p>
+          <h2 id="benefit-title">登入後即可使用的教練資源</h2>
+          <p class="section-text">整合課表、訓練分析與即時通知，讓你在忙碌的生活中仍能持續進步。</p>
+        </div>
+        <div class="benefit-grid">
+          <article class="benefit-card">
+            <h3>智慧課表同步</h3>
+            <p>所有預約自動同步至你的行事曆，並在開課前推送提醒通知。</p>
+          </article>
+          <article class="benefit-card">
+            <h3>訓練成效追蹤</h3>
+            <p>即時查看球種分析、課後回饋與成長指標，持續優化你的訓練策略。</p>
+          </article>
+          <article class="benefit-card">
+            <h3>會員專屬優惠</h3>
+            <p>享有場地租借折扣、裝備優惠與限定活動預先報名權。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="auth-footer-cta" aria-labelledby="cta-title">
+      <div class="container">
+        <h2 id="cta-title">還沒有帳號嗎？</h2>
+        <p>註冊成為會員即可解鎖專屬教練支援、個人化訓練計畫與課程預約管理。</p>
+        <a class="btn btn-primary" href="member-register.html">前往註冊</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-block">
+        <a class="logo" href="index.html">TennisPro</a>
+        <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
+      </div>
+      <div class="footer-block">
+        <span class="footer-title">快速導覽</span>
+        <a href="index.html">首頁</a>
+        <a href="about.html">關於我們</a>
+        <a href="booking.html">預約場地</a>
+        <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
+        <a href="member.html">會員中心</a>
+      </div>
+      <div class="footer-block">
+        <span class="footer-title">聯絡資訊</span>
+        <a href="mailto:hello@tennisproclub.tw">hello@tennisproclub.tw</a>
+        <a href="tel:+886223456789">+886 2 2345 6789</a>
+        <span>Line 官方帳號：@tennispro</span>
+      </div>
+      <div class="footer-block">
+        <span class="footer-title">追蹤我們</span>
+        <div class="social-links">
+          <a href="#">Facebook</a>
+          <a href="#">Instagram</a>
+          <a href="#">YouTube</a>
+        </div>
+      </div>
+    </div>
+    <div class="container footer-bottom">
+      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>Designed for tennis lovers in Taiwan.</span>
+    </div>
+  </footer>
+
+  <button class="to-top" type="button" aria-label="回到頁首">
+    <span>↑</span>
+  </button>
+
+  <div class="sr-only" aria-live="polite" id="global-status"></div>
+</body>
+</html>

--- a/member-login.html
+++ b/member-login.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>會員登入 | TennisPro Club</title>
-  <meta name="description" content="登入 TennisPro Club 會員專區，管理課程預約、訓練紀錄與會員福利。">
+  <title>會員登入 | 樂活網球 Club</title>
+  <meta name="description" content="登入 樂活網球 Club 會員專區，管理課程預約、訓練紀錄與會員福利。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body class="auth-page">
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -102,7 +102,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
       </div>
       <div class="footer-block">
@@ -130,7 +130,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>© 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/member-register.html
+++ b/member-register.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>加入會員 | TennisPro Club</title>
+  <meta name="description" content="註冊成為 TennisPro Club 會員，享受專屬教練支援、課程預約管理與多元訓練資源。">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/auth.css">
+  <script defer src="scripts.js"></script>
+</head>
+<body class="auth-page">
+  <header class="site-header" id="top">
+    <div class="container header-bar">
+      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
+        <span class="nav-toggle__bar"></span>
+        <span class="nav-toggle__bar"></span>
+        <span class="nav-toggle__bar"></span>
+        <span class="sr-only">開啟主選單</span>
+      </button>
+      <nav class="main-nav" id="main-nav">
+        <a href="index.html">首頁</a>
+        <a href="about.html">關於我們</a>
+        <a href="booking.html">預約場地</a>
+        <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
+        <a href="member.html">會員中心</a>
+      </nav>
+      <a class="btn btn-outline" href="member-login.html">會員登入</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="auth-hero">
+      <div class="container">
+        <div class="auth-copy">
+          <p class="eyebrow">Join TennisPro</p>
+          <h1>加入會員，打造你的專屬網球訓練旅程</h1>
+          <p>透過完整的會員系統管理課程、追蹤訓練數據並獲得教練團隊的專業建議。立即註冊即可開啟專屬進步路線。</p>
+        </div>
+        <div class="auth-card" aria-labelledby="register-title">
+          <div>
+            <h2 id="register-title">建立會員帳號</h2>
+            <p>填寫以下資訊，我們將在 24 小時內完成帳號啟用並寄送歡迎信。</p>
+          </div>
+          <form class="auth-form" aria-describedby="register-title">
+            <div class="form-field">
+              <label for="register-name">姓名</label>
+              <input id="register-name" name="name" type="text" placeholder="請輸入姓名" required>
+            </div>
+            <div class="form-field">
+              <label for="register-email">電子郵件</label>
+              <input id="register-email" name="email" type="email" placeholder="you@example.com" required>
+            </div>
+            <div class="form-field">
+              <label for="register-phone">連絡電話</label>
+              <input id="register-phone" name="phone" type="tel" placeholder="0912 345 678" required>
+            </div>
+            <div class="form-field">
+              <label for="register-plan">首選方案</label>
+              <select id="register-plan" name="plan" required>
+                <option value="">請選擇方案</option>
+                <option value="starter">成人入門｜Starter Pass</option>
+                <option value="junior">青少年競技｜Junior Elite</option>
+                <option value="premium">企業尊榮｜Corporate Plus</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="register-password">設定密碼</label>
+              <input id="register-password" name="password" type="password" placeholder="至少 8 碼英數組合" required>
+            </div>
+            <div class="form-field">
+              <label for="register-confirm-password">確認密碼</label>
+              <input id="register-confirm-password" name="confirm-password" type="password" placeholder="再次輸入密碼" required>
+            </div>
+            <div class="form-field" style="align-items: start;">
+              <label class="sr-only" for="register-consent">同意條款</label>
+              <div style="display:flex; gap:10px; align-items:flex-start;">
+                <input id="register-consent" type="checkbox" required>
+                <span class="auth-meta">我已閱讀並同意 <a href="#">會員使用條款</a> 與 <a href="#">個資保護聲明</a>。</span>
+              </div>
+            </div>
+            <div class="auth-actions">
+              <button class="btn btn-primary" type="submit">送出註冊</button>
+              <a class="btn btn-ghost" href="member-login.html">已有帳號？登入</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="auth-benefits" aria-labelledby="register-benefit-title">
+      <div class="container">
+        <div class="section-head" style="margin-bottom: 42px;">
+          <p class="eyebrow">會員優勢</p>
+          <h2 id="register-benefit-title">註冊後立即擁有的專屬服務</h2>
+          <p class="section-text">全方位整合線上預約、訓練紀錄與社群資源，協助你有效率地達成訓練目標。</p>
+        </div>
+        <div class="benefit-grid">
+          <article class="benefit-card">
+            <h3>專屬教練顧問</h3>
+            <p>加入後即刻匹配專屬教練顧問，定期檢視訓練計畫與進度。</p>
+          </article>
+          <article class="benefit-card">
+            <h3>多場館自由切換</h3>
+            <p>跨城市場館自由預約，行程變動也能快速調整訓練安排。</p>
+          </article>
+          <article class="benefit-card">
+            <h3>會員活動優先權</h3>
+            <p>優先參加球友交流賽、專題講座與國際觀賽團，拓展網球人脈。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="auth-footer-cta" aria-labelledby="register-cta-title">
+      <div class="container">
+        <h2 id="register-cta-title">已經完成註冊？</h2>
+        <p>立即登入會員中心安排下一堂課程，並查看最新的教練回饋。</p>
+        <a class="btn btn-primary" href="member-login.html">前往登入</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-block">
+        <a class="logo" href="index.html">TennisPro</a>
+        <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
+      </div>
+      <div class="footer-block">
+        <span class="footer-title">快速導覽</span>
+        <a href="index.html">首頁</a>
+        <a href="about.html">關於我們</a>
+        <a href="booking.html">預約場地</a>
+        <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
+        <a href="member.html">會員中心</a>
+      </div>
+      <div class="footer-block">
+        <span class="footer-title">聯絡資訊</span>
+        <a href="mailto:hello@tennisproclub.tw">hello@tennisproclub.tw</a>
+        <a href="tel:+886223456789">+886 2 2345 6789</a>
+        <span>Line 官方帳號：@tennispro</span>
+      </div>
+      <div class="footer-block">
+        <span class="footer-title">追蹤我們</span>
+        <div class="social-links">
+          <a href="#">Facebook</a>
+          <a href="#">Instagram</a>
+          <a href="#">YouTube</a>
+        </div>
+      </div>
+    </div>
+    <div class="container footer-bottom">
+      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>Designed for tennis lovers in Taiwan.</span>
+    </div>
+  </footer>
+
+  <button class="to-top" type="button" aria-label="回到頁首">
+    <span>↑</span>
+  </button>
+
+  <div class="sr-only" aria-live="polite" id="global-status"></div>
+</body>
+</html>

--- a/member-register.html
+++ b/member-register.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>加入會員 | TennisPro Club</title>
-  <meta name="description" content="註冊成為 TennisPro Club 會員，享受專屬教練支援、課程預約管理與多元訓練資源。">
+  <title>加入會員 | 樂活網球 Club</title>
+  <meta name="description" content="註冊成為 樂活網球 Club 會員，享受專屬教練支援、課程預約管理與多元訓練資源。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body class="auth-page">
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -38,7 +38,7 @@
     <section class="auth-hero">
       <div class="container">
         <div class="auth-copy">
-          <p class="eyebrow">Join TennisPro</p>
+          <p class="eyebrow">Join 樂活網球</p>
           <h1>加入會員，打造你的專屬網球訓練旅程</h1>
           <p>透過完整的會員系統管理課程、追蹤訓練數據並獲得教練團隊的專業建議。立即註冊即可開啟專屬進步路線。</p>
         </div>
@@ -129,7 +129,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
       </div>
       <div class="footer-block">
@@ -157,7 +157,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>© 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/member.html
+++ b/member.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>會員中心 | TennisPro Club</title>
+  <title>會員中心 | 樂活網球 Club</title>
   <meta name="description" content="網球會員專屬儀表板：掌握課程、成績與訊息，快速安排下一次訓練。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -262,7 +262,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
       </div>
       <div class="footer-block">
@@ -290,7 +290,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>© 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/member.html
+++ b/member.html
@@ -26,6 +26,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html" aria-current="page">會員中心</a>
       </nav>
       <a class="btn btn-outline" href="booking.html#booking-form">預約下一堂課</a>
@@ -270,6 +271,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </div>
       <div class="footer-block">

--- a/member.html
+++ b/member.html
@@ -143,8 +143,10 @@
                 <span>目標 72%</span>
               </div>
               <div class="target-progress" aria-label="目前達成率 65%">
-                <span style="width:65%"></span>
-                <span class="target-value">65%</span>
+                <div class="target-progress__track">
+                  <span style="width:65%"></span>
+                </div>
+                <span class="target-progress__value">65%</span>
               </div>
             </div>
             <div class="target-item">
@@ -153,8 +155,10 @@
                 <span>目標 60%</span>
               </div>
               <div class="target-progress" aria-label="目前達成率 58%">
-                <span style="width:58%"></span>
-                <span class="target-value">58%</span>
+                <div class="target-progress__track">
+                  <span style="width:58%"></span>
+                </div>
+                <span class="target-progress__value">58%</span>
               </div>
             </div>
             <div class="target-item">
@@ -163,8 +167,10 @@
                 <span>目標 Level 4</span>
               </div>
               <div class="target-progress" aria-label="目前達成率 80%">
-                <span style="width:80%"></span>
-                <span class="target-value">Level 3+</span>
+                <div class="target-progress__track">
+                  <span style="width:80%"></span>
+                </div>
+                <span class="target-progress__value">Level 3+</span>
               </div>
             </div>
           </div>

--- a/scripts.js
+++ b/scripts.js
@@ -493,12 +493,16 @@
 
       function renderSlots(payload) {
         if (!slotGrid) return;
+        const isSample = Boolean(payload && payload.isSample);
         const slots = computeSlots(payload);
+        const hasSlots = slots.length > 0;
+        slotGrid.classList.toggle("is-sample", isSample && hasSlots);
         slotGrid.innerHTML = "";
         if (slotSummary) {
           slotSummary.textContent = "";
+          slotSummary.classList.remove("is-sample");
         }
-        if (!slots.length) {
+        if (!hasSlots) {
           if (slotEmpty) {
             const locationText = locationLabels[payload.location] || "所選場館";
             const courtText = courtLabels[payload.court] || "指定球場";
@@ -514,7 +518,9 @@
         if (slotSummary) {
           const locationText = locationLabels[payload.location] || "";
           const courtText = courtLabels[payload.court] || "";
-          slotSummary.textContent = `${locationText}・${courtText}｜${fakeDateLabel} 找到 ${slots.length} 個推薦時段`;
+          const summaryPrefix = isSample ? "示意：" : "";
+          slotSummary.textContent = `${summaryPrefix}${locationText}・${courtText}｜${fakeDateLabel} 找到 ${slots.length} 個推薦時段`;
+          slotSummary.classList.toggle("is-sample", isSample);
         }
         const fragment = document.createDocumentFragment();
         slots.forEach(function (slot) {
@@ -542,6 +548,9 @@
             </div>
             <button class="btn btn-outline" type="button">預約這個時段</button>
           `;
+          if (isSample) {
+            card.classList.add("is-sample");
+          }
           fragment.appendChild(card);
         });
         slotGrid.appendChild(fragment);
@@ -593,6 +602,22 @@
           }
         });
       });
+
+      function renderSampleSlots() {
+        if (!slotGrid) return;
+        const samplePayload = {
+          location: "taipei",
+          court: "indoor-hard",
+          session: "private",
+          level: "intermediate",
+          timePreference: "any",
+          date: new Date(fakeDateSeeds.weekday.getTime()),
+          isSample: true
+        };
+        renderSlots(samplePayload);
+      }
+
+      renderSampleSlots();
 
       bookingForm.addEventListener("submit", function (event) {
         event.preventDefault();

--- a/scripts.js
+++ b/scripts.js
@@ -384,6 +384,15 @@
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
+      const fakeDateSeeds = {
+        weekday: new Date(2024, 6, 18),
+        weekend: new Date(2024, 6, 20)
+      };
+
+      Object.keys(fakeDateSeeds).forEach(function (key) {
+        fakeDateSeeds[key].setHours(0, 0, 0, 0);
+      });
+
       function formatInputDate(date) {
         const year = date.getFullYear();
         const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -394,6 +403,14 @@
       function formatDisplayDate(date) {
         const days = ["週日", "週一", "週二", "週三", "週四", "週五", "週六"];
         return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")} (${days[date.getDay()]})`;
+      }
+
+      function getFakeDateLabel(date) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+          return formatDisplayDate(fakeDateSeeds.weekday);
+        }
+        const seed = isWeekend(date) ? fakeDateSeeds.weekend : fakeDateSeeds.weekday;
+        return formatDisplayDate(seed);
       }
 
       function matchesTimePreference(pref, time) {
@@ -493,10 +510,11 @@
         if (slotEmpty) {
           slotEmpty.hidden = true;
         }
+        const fakeDateLabel = getFakeDateLabel(payload.date);
         if (slotSummary) {
           const locationText = locationLabels[payload.location] || "";
           const courtText = courtLabels[payload.court] || "";
-          slotSummary.textContent = `${locationText}・${courtText}｜${formatDisplayDate(payload.date)} 找到 ${slots.length} 個推薦時段`;
+          slotSummary.textContent = `${locationText}・${courtText}｜${fakeDateLabel} 找到 ${slots.length} 個推薦時段`;
         }
         const fragment = document.createDocumentFragment();
         slots.forEach(function (slot) {
@@ -512,7 +530,7 @@
           const noteText = slot.notes ? `<span>貼心服務：${slot.notes}</span>` : "";
           card.innerHTML = `
             <div class="slot-card__header">
-              <span>${slot.start} - ${slot.end}</span>
+              <span>${fakeDateLabel} ${slot.start} - ${slot.end}</span>
               <span class="badge">剩餘 ${slot.spots} 席</span>
             </div>
             <div class="slot-card__meta">

--- a/scripts.js
+++ b/scripts.js
@@ -507,7 +507,7 @@
           const levelText = slot.levels.map(function (level) {
             return levelLabels[level] || level;
           }).join(" / ");
-          const locationText = locationLabels[payload.location] || "TennisPro 場館";
+          const locationText = locationLabels[payload.location] || "樂活網球 場館";
           const courtText = courtLabels[payload.court] || "專屬球場";
           const noteText = slot.notes ? `<span>貼心服務：${slot.notes}</span>` : "";
           card.innerHTML = `

--- a/team-big5.txt
+++ b/team-big5.txt
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>?毀??隞晶 | TennisPro Club</title>
-  <meta name="description" content="隤? TennisPro Club ??璆剜?蝺渲??舀??嚗?閫??蝺渡?敹菔?隤????>
+  <title>?毀??隞晶 | 樂活網球 Club</title>
+  <meta name="description" content="隤? 樂活網球 Club ??璆剜?蝺渲??舀??嚗?閫??蝺渡?敹菔?隤????>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 擐?">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 擐?">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -297,7 +297,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>?靽⊥?雿飛?⊿?澆???撠惇??蝺渲???敺洵銝憿???撱箇?瘞貊??飛蝧??賬?/p>
       </div>
       <div class="footer-block">
@@ -324,7 +324,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>穢 2024 TennisPro Club. ?????/span>
+      <span>穢 2024 樂活網球 Club. ?????/span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/team.html
+++ b/team.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>教練團隊介紹 | TennisPro Club</title>
-  <meta name="description" content="認識 TennisPro Club 的專業教練與支援團隊，了解訓練理念與認證背景。">
+  <title>教練團隊介紹 | 樂活網球 Club</title>
+  <meta name="description" content="認識 樂活網球 Club 的專業教練與支援團隊，了解訓練理念與認證背景。">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-bar">
-      <a class="logo" href="index.html" aria-label="TennisPro 首頁">TennisPro</a>
+      <a class="logo" href="index.html" aria-label="樂活網球 首頁">樂活網球</a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-nav">
         <span class="nav-toggle__bar"></span>
         <span class="nav-toggle__bar"></span>
@@ -298,7 +298,7 @@
   <footer class="site-footer">
     <div class="container footer-grid">
       <div class="footer-block">
-        <a class="logo" href="index.html">TennisPro</a>
+        <a class="logo" href="index.html">樂活網球</a>
         <p>我們相信每位學員都值得擁有專屬的訓練藍圖，從第一顆球開始建立永續的學習動能。</p>
       </div>
       <div class="footer-block">
@@ -326,7 +326,7 @@
       </div>
     </div>
     <div class="container footer-bottom">
-      <span>© 2024 TennisPro Club. 版權所有。</span>
+      <span>© 2024 樂活網球 Club. 版權所有。</span>
       <span>Designed for tennis lovers in Taiwan.</span>
     </div>
   </footer>

--- a/team.html
+++ b/team.html
@@ -27,6 +27,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html" aria-current="page">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </nav>
       <a class="btn btn-outline" href="booking.html#booking-form">預約體驗課</a>
@@ -306,6 +307,7 @@
         <a href="about.html">關於我們</a>
         <a href="booking.html">預約場地</a>
         <a href="team.html">教練團隊</a>
+        <a href="member-login.html">會員登入</a>
         <a href="member.html">會員中心</a>
       </div>
       <div class="footer-block">


### PR DESCRIPTION
## Summary
- add dedicated member login and registration pages with supporting layout and content
- create shared authentication stylesheet and update site navigation and footer links to include the new login entry point
- tighten the booking steps eyebrow spacing to provide the requested 5px gap

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4e8fbe3dc832cab20f64661c924ff